### PR TITLE
Don't run the slow tests in the scheduled CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
     - main
   schedule:  # Scheduled workflows run on the latest commit on the default or base branch
-    - cron: '0 0 * * SUN'  # Run once a week at midnight on Sunday morning
+    - cron: '0 4 */3 * *'  # Run every 3 days at 4am
 
 jobs:
   ci_suite:


### PR DESCRIPTION
Github's machine runs out of space.