### PR TITLE
Clip sampled colors to [0, 255] instead of [0, 1] in MNISTColorizer.

### DIFF
--- a/conduit/data/datasets/vision/cmnist.py
+++ b/conduit/data/datasets/vision/cmnist.py
@@ -54,7 +54,7 @@ class MNISTColorizer:
         black: bool = True,
         greyscale: bool = False,
         color_indices: Optional[Union[List[int], slice]] = None,
-        normalize: bool = True,
+        normalize: bool = False,
         seed: Optional[int] = 42,
     ) -> None:
         """


### PR DESCRIPTION
Set normalize to False in ColoredMNIST dataset.
